### PR TITLE
Delete response serialization to string before cache creation

### DIFF
--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -8,7 +8,6 @@ import type { Options as HttpCacheSemanticsOptions } from 'http-cache-semantics'
 import type { Fetcher, FetcherResponse } from '@apollo/utils.fetcher';
 import {
   type KeyValueCache,
-  InMemoryLRUCache,
   PrefixingKeyValueCache,
 } from '@apollo/utils.keyvaluecache';
 import type {
@@ -16,6 +15,7 @@ import type {
   RequestOptions,
   ValueOrPromise,
 } from './RESTDataSource';
+import { NoopKeyValueCache } from './NoopKeyValueCache';
 
 // We want to use a couple internal properties of CachePolicy. (We could get
 // `_url` and `_status` off of the serialized CachePolicyObject, but `age()` is
@@ -38,7 +38,7 @@ export class HTTPCache<CO extends CacheOptions = CacheOptions> {
   private httpFetch: Fetcher;
 
   constructor(
-    keyValueCache: KeyValueCache = new InMemoryLRUCache<string, CO>(),
+    keyValueCache: KeyValueCache = new NoopKeyValueCache<string, CO>(),
     httpFetch: Fetcher = nodeFetch,
   ) {
     this.keyValueCache = new PrefixingKeyValueCache(

--- a/src/NoopKeyValueCache.ts
+++ b/src/NoopKeyValueCache.ts
@@ -1,0 +1,22 @@
+import type {
+  KeyValueCache,
+  KeyValueCacheSetOptions,
+} from '@apollo/utils.keyvaluecache';
+
+export class NoopKeyValueCache<
+  V = string,
+  SO extends KeyValueCacheSetOptions = KeyValueCacheSetOptions,
+> implements KeyValueCache<V, SO>
+{
+  async get(_key: string): Promise<V | undefined> {
+    return;
+  }
+
+  async set(_key: string, _value: V, _options?: SO): Promise<void> {
+    return;
+  }
+
+  async delete(_key: string): Promise<boolean | void> {
+    return;
+  }
+}

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -10,6 +10,7 @@ import { GraphQLError } from 'graphql';
 import type { Options as HttpCacheSemanticsOptions } from 'http-cache-semantics';
 import cloneDeep from 'lodash.clonedeep';
 import isPlainObject from 'lodash.isplainobject';
+import type { CacheItem } from './HTTPCache';
 import { HTTPCache } from './HTTPCache';
 
 export type ValueOrPromise<T> = T | Promise<T>;
@@ -140,8 +141,11 @@ export interface CacheOptions {
 
 const NODE_ENV = process.env.NODE_ENV;
 
-export interface DataSourceConfig {
-  cache?: KeyValueCache;
+export interface DataSourceConfig<
+  V extends CacheItem = CacheItem,
+  CO extends CacheOptions = CacheOptions,
+> {
+  cache?: KeyValueCache<V, CO>;
   fetch?: Fetcher;
   logger?: Logger;
 }

--- a/src/__tests__/FakeableTTLTestingCache.ts
+++ b/src/__tests__/FakeableTTLTestingCache.ts
@@ -7,11 +7,17 @@
 // time calculation in this mock cache as well.
 //
 // (Borrowed from apollo-server.)
-export class FakeableTTLTestingCache {
+import type { CacheItem } from '../HTTPCache';
+import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
+import type { CacheOptions } from '../RESTDataSource';
+
+export class FakeableTTLTestingCache
+  implements KeyValueCache<CacheItem, CacheOptions>
+{
   constructor(
     private cache: Map<
       string,
-      { value: string; deadline: number | null }
+      { value: CacheItem; deadline: number | null }
     > = new Map(),
   ) {}
 
@@ -27,12 +33,12 @@ export class FakeableTTLTestingCache {
 
   async set(
     key: string,
-    value: string,
-    { ttl }: { ttl: number | null } = { ttl: null },
+    value: CacheItem,
+    options: CacheOptions = { ttl: undefined },
   ) {
     this.cache.set(key, {
       value,
-      deadline: ttl ? Date.now() + ttl * 1000 : null,
+      deadline: options.ttl ? Date.now() + options.ttl * 1000 : null,
     });
   }
 

--- a/src/__tests__/HTTPCache.test.ts
+++ b/src/__tests__/HTTPCache.test.ts
@@ -425,7 +425,7 @@ describe('HTTPCache', () => {
 
     expect(storeSet).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(String),
+      expect.any(Object),
       { ttl: 30 },
     );
     storeSet.mockRestore();
@@ -441,7 +441,7 @@ describe('HTTPCache', () => {
 
     expect(storeSet).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(String),
+      expect.any(Object),
       { ttl: 60 },
     );
 
@@ -468,7 +468,7 @@ describe('HTTPCache', () => {
 
     expect(storeSet).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(String),
+      expect.any(Object),
       { ttl: 20, tags: ['foo', 'bar'] },
     );
 

--- a/src/__tests__/NoopKeyValueCache.test.ts
+++ b/src/__tests__/NoopKeyValueCache.test.ts
@@ -1,0 +1,37 @@
+import { NoopKeyValueCache } from '../NoopKeyValueCache';
+
+describe('NoopKeyValueCache', () => {
+  let cache: NoopKeyValueCache;
+
+  const cacheKeyMock = 'key';
+
+  beforeEach(() => {
+    cache = new NoopKeyValueCache();
+  });
+
+  describe('get', () => {
+    it('should return undefined', async () => {
+      const result = await cache.get(cacheKeyMock);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('set', () => {
+    it('should return undefined', async () => {
+      const result = await cache.set(cacheKeyMock, 'data', {
+        ttl: 1000,
+      });
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('delete', () => {
+    it('should return undefined', async () => {
+      const result = await cache.delete(cacheKeyMock);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -15,7 +15,7 @@ import { nockAfterEach, nockBeforeEach } from './nockAssertions';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import { Headers as NodeFetchHeaders } from 'node-fetch';
 import type { Logger } from '@apollo/utils.logger';
-import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
+import { FakeableTTLTestingCache } from './FakeableTTLTestingCache';
 
 const apiUrl = 'https://api.example.com';
 
@@ -1457,7 +1457,7 @@ describe('RESTDataSource', () => {
 
           constructor() {
             super({
-              cache: new InMemoryLRUCache(),
+              cache: new FakeableTTLTestingCache(),
             });
           }
 
@@ -1767,7 +1767,7 @@ describe('RESTDataSource', () => {
 
           constructor() {
             super({
-              cache: new InMemoryLRUCache(),
+              cache: new FakeableTTLTestingCache(),
             });
           }
 
@@ -1807,7 +1807,7 @@ describe('RESTDataSource', () => {
 
             constructor() {
               super({
-                cache: new InMemoryLRUCache(),
+                cache: new FakeableTTLTestingCache(),
               });
             }
 
@@ -1875,7 +1875,7 @@ describe('RESTDataSource', () => {
 
           constructor() {
             super({
-              cache: new InMemoryLRUCache(),
+              cache: new FakeableTTLTestingCache(),
             });
           }
 
@@ -1921,7 +1921,7 @@ describe('RESTDataSource', () => {
 
           constructor() {
             super({
-              cache: new InMemoryLRUCache(),
+              cache: new FakeableTTLTestingCache(),
             });
           }
 
@@ -1989,7 +1989,7 @@ describe('RESTDataSource', () => {
 
             constructor() {
               super({
-                cache: new InMemoryLRUCache(),
+                cache: new FakeableTTLTestingCache(),
               });
             }
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -15,6 +15,7 @@ import { nockAfterEach, nockBeforeEach } from './nockAssertions';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import { Headers as NodeFetchHeaders } from 'node-fetch';
 import type { Logger } from '@apollo/utils.logger';
+import { InMemoryLRUCache } from '@apollo/utils.keyvaluecache';
 
 const apiUrl = 'https://api.example.com';
 
@@ -1453,6 +1454,13 @@ describe('RESTDataSource', () => {
       it('allows specifying a custom cache key via cacheKey used for HTTP-header-sensitive cache', async () => {
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
+
+          constructor() {
+            super({
+              cache: new InMemoryLRUCache(),
+            });
+          }
+
           protected override requestDeduplicationPolicyFor() {
             return { policy: 'do-not-deduplicate' } as const;
           }
@@ -1756,6 +1764,13 @@ describe('RESTDataSource', () => {
       it('allows setting cache options for each request', async () => {
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
+
+          constructor() {
+            super({
+              cache: new InMemoryLRUCache(),
+            });
+          }
+
           protected override requestDeduplicationPolicyFor() {
             return { policy: 'do-not-deduplicate' } as const;
           }
@@ -1789,6 +1804,12 @@ describe('RESTDataSource', () => {
         const dataSource =
           new (class extends RESTDataSource<CustomCacheOptions> {
             override baseURL = 'https://api.example.com';
+
+            constructor() {
+              super({
+                cache: new InMemoryLRUCache(),
+              });
+            }
 
             getFoo(id: number) {
               return this.fetch(`foo/${id}`, {
@@ -1852,6 +1873,12 @@ describe('RESTDataSource', () => {
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
 
+          constructor() {
+            super({
+              cache: new InMemoryLRUCache(),
+            });
+          }
+
           getFoo(id: number, shared: boolean) {
             return this.fetch(`foo/${id}`, {
               httpCacheSemanticsCachePolicyOptions: { shared },
@@ -1891,6 +1918,12 @@ describe('RESTDataSource', () => {
 
         const dataSource = new (class extends RESTDataSource {
           override baseURL = apiUrl;
+
+          constructor() {
+            super({
+              cache: new InMemoryLRUCache(),
+            });
+          }
 
           getFoo(id: number) {
             return this.fetch(`foo/${id}`, {
@@ -1953,6 +1986,12 @@ describe('RESTDataSource', () => {
         it('for a cacheable but not de-duped request', async () => {
           const dataSource = new (class extends RESTDataSource {
             override baseURL = 'https://api.example.com';
+
+            constructor() {
+              super({
+                cache: new InMemoryLRUCache(),
+              });
+            }
 
             postFoo() {
               return this.fetch('foo', {


### PR DESCRIPTION
## Description

- Delete response serialization to string before cache creation to reduce cache item size
- Replace InMemoryLRUCache with stub to reduce RAM usage
